### PR TITLE
fix(ci): downgraded actions/checkout to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: Python Semantic Release
         if: github.repository == 'socialpoint-labs/spine-json-lib'
         uses: AlphaMycelium/psr-action@master

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ flake8==3.7.8
 tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
-python-semantic-release==4.6.0
 deepdiff==4.0.9
 
 pytest==4.6.5


### PR DESCRIPTION
actions/checkout@v2 contains performance optimisations that avoid the script to read repository's history in order to figure out what kind of version apply (major/minor/patch)