### PR TITLE
Feat/add images nodes to graph

### DIFF
--- a/spine_json_lib/data/data_types/ik.py
+++ b/spine_json_lib/data/data_types/ik.py
@@ -43,6 +43,7 @@ class IkTimeline(SpineData):
         "bendPositive": True,
         "stretch": False,
         "curve": [],
+        "compress": False,
         "c2": 0,
         "c3": 1,
         "c4": 1,
@@ -58,6 +59,7 @@ class IkTimeline(SpineData):
         self.c2 = values.get("c2")
         self.c3 = values.get("c3")
         self.c4 = values.get("c4")
+        self.compress = values.get("compress")
         self.stretch = values.get("stretch")
 
         super(IkTimeline, self).__init__(values)

--- a/spine_json_lib/data/spine_anim_data.py
+++ b/spine_json_lib/data/spine_anim_data.py
@@ -91,10 +91,6 @@ class SpineAnimationData(SpineData):
                 return bone
         return None
 
-    @staticmethod
-    def parse_skins_from_version(version: SpineVersion, data_skins) -> List[Skin38]:
-        return [Skin38(value) for value in data_skins]
-
     def get_skin(self, skin_id):
         for skin in self.skins:
             if skin.name == skin_id:
@@ -278,17 +274,8 @@ class SpineAnimationData(SpineData):
                 attachments_ids = attachment_data.keys()
 
                 for attachment_id in attachments_ids:
-                    path_attachment = None
-                    if hasattr(attachment_data[attachment_id], "path"):
-                        path_attachment = attachment_data[attachment_id].path
-                    attachment_unique_id = (
-                        path_attachment
-                        or attachment_data[attachment_id].name
-                        or attachment_id
-                    )
-
                     if attachment_id not in l_attachments_used:
-                        attachments_to_remove |= frozenset([attachment_unique_id])
+                        attachments_to_remove |= frozenset([attachment_id])
 
         invisible_slots = slots_set - visible_slots
         return invisible_slots, attachments_to_remove

--- a/spine_json_lib/test/test_spine_animation_editor.py
+++ b/spine_json_lib/test/test_spine_animation_editor.py
@@ -193,7 +193,7 @@ class TestSpineAnimationEditor:
                 "fx_purple_smoke_5",
                 "fx_purple_smoke_4",
                 "fx_purple_smoke_7",
-                "fx_purple_smoke_basis",
+                "fx/fx_purple_smoke_basis",
                 "fx_purple_smoke_1",
                 "fx_purple_smoke_0",
                 "fx_purple_smoke_3",


### PR DESCRIPTION
### WHY:

- It is possible that two different attachments have the same image associated, but using a different tint or alpha in different frames.
- So with the current approach of having **"BONE -> SLOT -> ATTACHMENT"** there could be the case when the second attachments gets marked to be removed, but because is sharing the image with another one we will miss that image in the final animation.

### HOW:

- Adding a new type of node **IMAGE** to the graph. Those nodes will be children of **ATTACHMENT**, so after "cleaning" the animation **IMAGE** nodes will be erased in case of not having parents (_Root Nodes_)

![Screenshot 2020-06-17 at 17 20 18](https://user-images.githubusercontent.com/4124896/84916817-d8745980-b0be-11ea-86f5-787645b29eb4.png)
