### PR TITLE
Fix/image nodes

### DIFF
--- a/spine_json_lib/data/spine_anim_data.py
+++ b/spine_json_lib/data/spine_anim_data.py
@@ -204,9 +204,9 @@ class SpineAnimationData(SpineData):
         for slot_id, slot_data in anim_slots.items():
             # By default we have to add the slot attachment base data as they are normally missing
             # in the json info for optimization
-            slot_used_attachments = slot_data.get_used_attachments() + [
-                slots_dict[slot_id].attachment
-            ]
+            slot_used_attachments = slot_data.get_used_attachments()
+            if slots_dict[slot_id].attachment is not None:
+                slot_used_attachments.append(slots_dict[slot_id].attachment)
 
             # Discarding slot if:
             # 1 -) At least 1 animation it is not empty

--- a/spine_json_lib/deserializer/spine_nodes.py
+++ b/spine_json_lib/deserializer/spine_nodes.py
@@ -236,22 +236,21 @@ class SpineGraphParser(IGraphParser):
                     node_data=attachment_data.node_data,
                 )
 
-                image_id = _data.get("path") or _data.get("name") or _id
-                image_node_data = SpineNodeData(
-                    node_data={},
-                    node_type=NodeType.IMAGE,
-                    node_base_id=image_id
+            image_id = _data.get("path") or _data.get("name") or _id
+            image_node_data = SpineNodeData(
+                node_data={},
+                node_type=NodeType.IMAGE,
+                node_base_id=image_id
+            )
+
+            if graph.get_node(image_node_data.node_id) is None:
+                graph.add_node(
+                    node_type=image_node_data.node_type,
+                    node_id=image_node_data.node_id,
+                    node_data=image_node_data.node_data,
                 )
 
-                if graph.get_node(image_node_data.node_id) is None:
-                    graph.add_node(
-                        node_type=image_node_data.node_type,
-                        node_id=image_node_data.node_id,
-                        node_data=image_node_data.node_data,
-                    )
-
-                graph.add_edge(attachment_data.node_id, image_node_data.node_id)
-
+            graph.add_edge(attachment_data.node_id, image_node_data.node_id)
             graph.add_edge(slot_parent.node_id, attachment_data.node_id)
 
     @staticmethod

--- a/spine_json_lib/spine_animation_editor.py
+++ b/spine_json_lib/spine_animation_editor.py
@@ -171,7 +171,18 @@ class SpineAnimationEditor(object):
         print("Removed slots {}".format(slots_to_remove))
 
         self.remove_attachments(attachments_ids=attachments_to_remove)
-        print("Removed attachments {}".format(attachments_to_remove))
+        detached_attachments = self.spine_graph.remove_heads_of_type(
+            NodeType.ATTACHMENT.name
+        )
+        detached_attachments += self.spine_graph.remove_leafs_of_type(
+            NodeType.ATTACHMENT.name
+        )
+        print(
+            "Removed attachments {}".format(
+                list(attachments_to_remove) + detached_attachments
+            )
+        )
+
         images_node = self.spine_graph.remove_heads_of_type(NodeType.IMAGE.name)
 
         # Remove reference to region attachments in images json file


### PR DESCRIPTION
- Fix: slots with no attachments where never marked as "invisible" in setup pose
- Fix: remove attachments that are "leafs" or "heads" of "graph" for optimisation purposes
- Fix: same attachment can have different "images" added as children in different skins as we can see in the image attached
![Screenshot 2020-06-22 at 19 11 08](https://user-images.githubusercontent.com/4124896/85315926-2e307380-b4bc-11ea-81b3-2b1a706e3236.png)
![Screenshot 2020-06-22 at 19 10 48](https://user-images.githubusercontent.com/4124896/85315935-3092cd80-b4bc-11ea-83a3-4bbef9b86a2b.png)
