### PR TITLE
fix: count also the removed images refs of type SkinLinkedMesh

### DIFF
--- a/spine_json_lib/data/spine_anim_data.py
+++ b/spine_json_lib/data/spine_anim_data.py
@@ -141,7 +141,7 @@ class SpineAnimationData(SpineData):
                     if image_path is not None:
                         removed_attachments.setdefault(attachment_id, {})
                         removed_attachments[attachment_id][slot_id] = image_path
-                elif isinstance(slot_data, SkinMesh):
+                elif isinstance(slot_data, (SkinMesh, SkinLinkedMesh)):
                     mesh_image_path = slot_data.path or slot_data.name
                     removed_images.append(mesh_image_path)
                 elif hasattr(slot_data, "path") and slot_data.path is not None:


### PR DESCRIPTION
We were not saving removed refs to SkinLinkedMeshes when removing certain skins. 
That's why sometimes textures were including unused images after removing certain skins.