### PR TITLE
fix: remove refs to slots/attachments in 'deforms' after deleted

### DIFF
--- a/spine_json_lib/data/data_types/animation.py
+++ b/spine_json_lib/data/data_types/animation.py
@@ -94,3 +94,24 @@ class Animation(SpineData):
     def remove_draw_order_with_ids(self, slots_ids, original_slots):
         for draw_order in self.drawOrder:
             draw_order.remove_offsets_with_ids(slots_ids, original_slots)
+
+    def remove_deforms_using_slots(self, slots_ids):
+        self.deform = {
+            k: {k2: v2 for k2, v2 in v.items() if k2 not in slots_ids}
+            for k, v in self.deform.items()
+        }
+
+    def remove_deforms_with_attachments_on_skin(self, attachments_ids, skin_id):
+        skin_deform = self.deform.get(skin_id)
+
+        if skin_deform is None:
+            return
+
+        self.deform[skin_id] = {
+            k2: {
+                k3: deform_list
+                for k3, deform_list in v2.items()
+                if k3 not in attachments_ids
+            }
+            for k2, v2 in skin_deform.items()
+        }

--- a/spine_json_lib/spine_animation_editor.py
+++ b/spine_json_lib/spine_animation_editor.py
@@ -310,6 +310,11 @@ class SpineAnimationEditor(object):
                     if attachment_id in attachment_ids:
                         del data_current_skin.attachments[slot_id][attachment_id]
 
+            for animation in self.spine_anim_data.data.animations.values():
+                animation.remove_deforms_with_attachments_on_skin(
+                    attachments_ids=attachment_ids, skin_id=data.name
+                )
+
         self.spine_anim_data.data.skins = skins_data
 
     def _clean_attachments_in_slots(self, attachments_ids: List[str]) -> None:
@@ -333,8 +338,8 @@ class SpineAnimationEditor(object):
             for slot_id, slots_data in anim_data.slots.items():
                 if slot_id in slots_ids:
                     del anim_data_slots[slot_id]
-
             anim_data.slots = anim_data_slots
+            anim_data.remove_deforms_using_slots(slots_ids)
 
     def _clean_draw_order_refs(
         self, slots_ids: List[str], original_slots: List[Slot]


### PR DESCRIPTION
When removing "slots" or "attachments" in an animation, we have to remove also references to them saved in "deforms" otherwise the json file will get corrupted.